### PR TITLE
Add runtime requirement to ffmpeg

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -29,3 +29,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -81,4 +81,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -32,8 +32,10 @@ requirements:
     - openexr ==2.3.*
   run:
     # boost and libwebp don't have a run_exports section
-    - boost ==1.69.0
-    - libwebp ==1.0.1
+    - {{ pin_compatible('boost', max_pin='x.x.x') }}
+    - {{ pin_compatible('libwebp', max_pin='x.x') }}
+    # ffmpeg 3.x does not have a run-export section
+    - {{ pin_compatible('ffmpeg', max_pin='x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
ffmpeg 3.x does not have a `run_exports` section unfortunately.